### PR TITLE
Typo: defaul -> default in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It may be helpful to look at the structure of the simulated objects to know what
 ```R
 library(provoc)
 
-# Siumlate with defaul parameters
+# Siumlate with default parameters
 # (Omicron sublineages with a handful of mutations chosen randomly)
 varmat <- simulate_varmat()
 


### PR DESCRIPTION
This looks really nice. Whilst reading through the source I noted a small typo in the README which this PR fixes.